### PR TITLE
Refactor/7-Improved-remittance-function

### DIFF
--- a/src/main/java/com/minipay/MinipayApplication.java
+++ b/src/main/java/com/minipay/MinipayApplication.java
@@ -2,8 +2,10 @@ package com.minipay;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class MinipayApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/minipay/account/dto/AccountDTO.java
+++ b/src/main/java/com/minipay/account/dto/AccountDTO.java
@@ -1,6 +1,7 @@
 package com.minipay.account.dto;
 
 import com.minipay.account.domain.Type;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +12,7 @@ public class AccountDTO {
     private Long userId;
     private Type type;
 
+    @Builder
     public AccountDTO(Long userId, Type type) {
         this.userId = userId;
         this.type = type;

--- a/src/main/java/com/minipay/account/dto/DepositDTO.java
+++ b/src/main/java/com/minipay/account/dto/DepositDTO.java
@@ -1,5 +1,6 @@
 package com.minipay.account.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,6 +11,7 @@ public class DepositDTO {
     private Long accountId;
     private long balance;
 
+    @Builder
     public DepositDTO(Long accountId, long balance) {
         this.accountId = accountId;
         this.balance = balance;

--- a/src/main/java/com/minipay/account/repository/AccountRepository.java
+++ b/src/main/java/com/minipay/account/repository/AccountRepository.java
@@ -2,7 +2,11 @@ package com.minipay.account.repository;
 
 import com.minipay.account.domain.Account;
 import com.minipay.account.domain.Type;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,4 +17,8 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
     List<Account> findAllByUserId(Long userId);
 
     Account findByUserIdAndType(Long userId, Type type);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select a from Account a where a.id = :id")
+    Account findByIdWithPessimisticLock(@Param("id") Long id);
 }

--- a/src/main/java/com/minipay/account/service/AccountService.java
+++ b/src/main/java/com/minipay/account/service/AccountService.java
@@ -113,39 +113,42 @@ public class AccountService {
     @Transactional
     public void remittance(RemittanceDTO request) {
 
-        Account senderAccount = accountRepository.findById(request.getSenderAccountId()).orElseThrow(IllegalArgumentException::new);
-        Account receiverAccount = accountRepository.findById(request.getReceiverAccountId()).orElseThrow(IllegalArgumentException::new);
+        Account senderAccount = accountRepository.findByIdWithPessimisticLock(request.getSenderAccountId());
+        Account receiverAccount = accountRepository.findByIdWithPessimisticLock(request.getReceiverAccountId());
 
         if (senderAccount.getBalance() >= request.getBalance()) { //가진돈이 보낼돈보다 많다면
             senderAccount.deposit(-request.getBalance());
             receiverAccount.deposit(request.getBalance());
         } else { //가진돈이 보낼돈보다 적다면
             LocalDate today = LocalDate.now();
-
-            List<Deposit> deposits = depositRepository.findDepositsForToday(senderAccount.getId(), today);
-            long totalDeposit = deposits.stream().mapToLong(Deposit::getAmount).sum();
-
-            if (totalDeposit + request.getBalance() > TODAY_LIMIT) { // 오늘충전금액 + 보낼금액 > 일일 충전 한도
-                throw new IllegalArgumentException("일일 입금 금액 초과");
-            } else {
-                long chargeAmount = ((request.getBalance() + 9999 - senderAccount.getBalance()) / 10000) * 10000; //충전금액
-
-                Deposit deposit = Deposit.builder()
-                        .account(senderAccount)
-                        .amount(chargeAmount)
-                        .timeStamp(today)
-                        .build();
-
-                System.out.println(chargeAmount);
-                System.out.println(request.getBalance());
-
-                depositRepository.save(deposit);
-
-                senderAccount.deposit(-request.getBalance() + chargeAmount);
-                receiverAccount.deposit(request.getBalance());
-
-            }
+            long totalDeposit = getTotalDeposit(senderAccount, today);
+            daliyLimitDetermination(request, totalDeposit, senderAccount, today, receiverAccount);
         }
+    }
+
+    private void daliyLimitDetermination(RemittanceDTO request, long totalDeposit, Account senderAccount, LocalDate today, Account receiverAccount) {
+        if (totalDeposit + request.getBalance() > TODAY_LIMIT) { // 오늘충전금액 + 보낼금액 > 일일 충전 한도
+            throw new IllegalArgumentException("일일 입금 금액 초과");
+        } else {
+            long chargeAmount = ((request.getBalance() + 9999 - senderAccount.getBalance()) / 10000) * 10000; //충전금액
+
+            Deposit deposit = Deposit.builder()
+                    .account(senderAccount)
+                    .amount(chargeAmount)
+                    .timeStamp(today)
+                    .build();
+
+            depositRepository.save(deposit);
+
+            senderAccount.deposit(-request.getBalance() + chargeAmount);
+            receiverAccount.deposit(request.getBalance());
+
+        }
+    }
+
+    private long getTotalDeposit(Account senderAccount, LocalDate today) {
+        List<Deposit> deposits = depositRepository.findDepositsForToday(senderAccount.getId(), today);
+        return deposits.stream().mapToLong(Deposit::getAmount).sum();
     }
 
 }

--- a/src/main/java/com/minipay/daliyLimit/domain/DailyLimit.java
+++ b/src/main/java/com/minipay/daliyLimit/domain/DailyLimit.java
@@ -1,0 +1,36 @@
+package com.minipay.daliyLimit.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class DailyLimit {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private long dailyTotalBalance;
+
+    @Builder
+    public DailyLimit(Long userId, long dailyTotalBalance) {
+        this.userId = userId;
+        this.dailyTotalBalance = dailyTotalBalance;
+    }
+
+    public void addBalance(long dailyTotalBalance) {
+        this.dailyTotalBalance += dailyTotalBalance;
+    }
+
+    public void resetDailyBalance(long dailyTotalBalance) {
+        this.dailyTotalBalance = 0;
+    }
+}

--- a/src/main/java/com/minipay/daliyLimit/repository/DailyLimitRepository.java
+++ b/src/main/java/com/minipay/daliyLimit/repository/DailyLimitRepository.java
@@ -1,0 +1,9 @@
+package com.minipay.daliyLimit.repository;
+
+import com.minipay.daliyLimit.domain.DailyLimit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DailyLimitRepository extends JpaRepository<DailyLimit, Long> {
+}

--- a/src/main/java/com/minipay/deposit/domain/Deposit.java
+++ b/src/main/java/com/minipay/deposit/domain/Deposit.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -23,10 +23,10 @@ public class Deposit {
 
     private long amount;
 
-    private LocalDate timeStamp;
+    private LocalDateTime timeStamp;
 
     @Builder
-    public Deposit(Account account, long amount, LocalDate timeStamp) {
+    public Deposit(Account account, long amount, LocalDateTime timeStamp) {
         this.account = account;
         this.amount = amount;
         this.timeStamp = timeStamp;

--- a/src/main/java/com/minipay/user/dto/SignupDTO.java
+++ b/src/main/java/com/minipay/user/dto/SignupDTO.java
@@ -1,5 +1,6 @@
 package com.minipay.user.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,6 +11,7 @@ public class SignupDTO {
     private String username;
     private String password;
 
+    @Builder
     public SignupDTO(String username, String password) {
         this.username = username;
         this.password = password;

--- a/src/main/java/com/minipay/user/service/UserService.java
+++ b/src/main/java/com/minipay/user/service/UserService.java
@@ -3,6 +3,8 @@ package com.minipay.user.service;
 import com.minipay.account.domain.Account;
 import com.minipay.account.domain.Type;
 import com.minipay.account.repository.AccountRepository;
+import com.minipay.daliyLimit.domain.DailyLimit;
+import com.minipay.daliyLimit.repository.DailyLimitRepository;
 import com.minipay.user.domain.User;
 import com.minipay.user.dto.SignupDTO;
 import com.minipay.user.repository.UserRepository;
@@ -18,6 +20,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final AccountRepository accountRepository;
+    private final DailyLimitRepository dailyLimitRepository;
 
     @Transactional // 회원가입
     public void save(SignupDTO request) {
@@ -37,5 +40,12 @@ public class UserService {
                 .build();
 
         accountRepository.save(account);
+
+        DailyLimit dailyLimit = DailyLimit.builder()
+                .userId(user.getId())
+                .dailyTotalBalance(0L)
+                .build();
+
+        dailyLimitRepository.save(dailyLimit);
     }
 }


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

**송금 기능에서 많은 사용자가 동시에 한 계좌로 송금을 시도할 때 발생하는 데이터 일관성 문제** 
- 데이터 베이스 동시성 제어를 강화 
- 다수의 사용자가 한 계좌로 송금할 때 발생하는 경쟁 상태를 방지하고, 일관성 있게 처리해야한다.

`비관적 락 > 낙관적 락`
- 충돌 빈도 : 다수의 사용자가 동시에 같은 계좌로 송금하는 시나리오는 충돌이 빈번하게 발생할 가능성이 크므로, 비관적 락 이 더 알맞다.
- 데이터 일관성 : 비관적 락은 트랜잭션이 진행되는 동안 다른 트랜잭션이 해당 데이터에 접근하지 못하게 한다.

`100명의 유저가 한 명의 계좌로 동시에 송금하는 시나리오`
- 비관적 락을 도입하기 전에는 데이터 일관성이 보장되지 않았고, 충돌이 빈번했다.

```
@Lock(LockModeType.PESSIMISTIC_WRITE)
@Query("select a from Account a where a.id = :id")
Account findByIdWithPessimisticLock(@Param("id") Long id);
```

- 비관적 락을 도입한 후, 테스트가 잘 수행되었다.
 
<img width="966" alt="스크린샷 2024-07-16 오후 1 51 42" src="https://github.com/user-attachments/assets/ce868f60-0498-471e-9e42-17e84f882b0b">
<br>
<br>


**일일 한도 관리에 대한 고민**

유저들은 하루에 본인의 메인계좌로 입금할 수 있는 금액이 300만원으로 제한되어있다.
기존 방식에서는 유저들의 입금내역을 DB에 저장한 후, 일일 한도를 계산하기 위해 해당 유저의 오늘 날짜를 기준으로 DB에서 데이터를 조회해서 모든 입금내역을 합산했다.

`기존 방식의 문제점`
-> 입금 내역은 시간이 지날수록 계속해서 축적되지만, 일일 한도 데이터는 그날 하루만 필요하고, 하루가 지나면 더 이상 필요가 없다.
-> 계속해서 쌓이는 입금 내역을 바탕으로 일일 한도를 계산하기 위해 데이터를 조회하고 합산하는 작업은 시스템에 상당한 부하를 초래할 수 있다.

`해결 방안`
'dailyLimit' 엔티티를 만들어서 유저의 입금 금액을 관리하고, 매일 정해진 시간에 이를 초기화하는 방법으로 구현
- 각 유저의 일일 입금 한도를 관리하는 'dailyLimit' 엔티티 생성
- 유저가 입금할 때마다 엔티티의 'balance' 필드에 입금 금액을 더해줌
- @Scheduled 어노테이션을 활용하여 매일 정해진 시간에 모든 유저의 'balance' 필드를 0으로 초기화하는 스케줄러 구현

`효과`
- 일일 한도 계산을 위해 대량의 입금 내역 데이터를 조회하고 합산할 필요 X -> 시스템 부하 줄이고 성능 향상
- 매일 정해진 시간에 초기화 작업을 통해 데이터 일관성을 유지하고 효율적인 관리 가능 

## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 코드 리팩토링

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.

## 📎 관련 이슈

#7 

## 🙌 리뷰 및 피드백
