### PR TITLE
Feat/9 update saving account

### DIFF
--- a/src/main/java/com/minipay/account/controller/AccountController.java
+++ b/src/main/java/com/minipay/account/controller/AccountController.java
@@ -36,7 +36,7 @@ public class AccountController {
     @PatchMapping("/withdrawal") //이체 메인 -> 적금
     public ResponseEntity<?> withdrawal(@RequestBody WithdrawalDTO request) {
 
-        accountService.withdrawal1(request);
+        accountService.withdrawal(request);
 
         return ResponseEntity.ok().body(null);
     }

--- a/src/main/java/com/minipay/account/domain/Account.java
+++ b/src/main/java/com/minipay/account/domain/Account.java
@@ -34,4 +34,8 @@ public class Account {
     public void deposit(long balance) {
         this.balance += balance;
     }
+
+    public void addInterest(long balance) {
+        this.balance += balance;
+    }
 }

--- a/src/main/java/com/minipay/account/domain/Account.java
+++ b/src/main/java/com/minipay/account/domain/Account.java
@@ -24,11 +24,14 @@ public class Account {
     @Enumerated(value = EnumType.STRING)
     private Type type;
 
+    private long regularFee;
+
     @Builder
-    public Account(User user, long balance, Type type) {
+    public Account(User user, long balance, Type type, long regularFee) {
         this.user = user;
         this.balance = balance;
         this.type = type;
+        this.regularFee = regularFee;
     }
 
     public void deposit(long balance) {

--- a/src/main/java/com/minipay/account/domain/Type.java
+++ b/src/main/java/com/minipay/account/domain/Type.java
@@ -1,5 +1,5 @@
 package com.minipay.account.domain;
 
 public enum Type {
-    MAIN, SAVING
+    MAIN, FREE_SAVING, REGULAR_SAVING
 }

--- a/src/main/java/com/minipay/account/dto/AccountDTO.java
+++ b/src/main/java/com/minipay/account/dto/AccountDTO.java
@@ -11,10 +11,12 @@ public class AccountDTO {
 
     private Long userId;
     private Type type;
+    private long regularFee;
 
     @Builder
-    public AccountDTO(Long userId, Type type) {
+    public AccountDTO(Long userId, Type type, long regularFee) {
         this.userId = userId;
         this.type = type;
+        this.regularFee = regularFee;
     }
 }

--- a/src/main/java/com/minipay/account/repository/AccountRepository.java
+++ b/src/main/java/com/minipay/account/repository/AccountRepository.java
@@ -21,4 +21,9 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select a from Account a where a.id = :id")
     Account findByIdWithPessimisticLock(@Param("id") Long id);
+
+    @Query("SELECT a FROM Account a WHERE a.type = 'FREE_SAVING' or a.type = 'REGULAR_SAVING'")
+    List<Account> findAllSavingsAccounts();
+
+
 }

--- a/src/main/java/com/minipay/account/service/AccountService.java
+++ b/src/main/java/com/minipay/account/service/AccountService.java
@@ -74,7 +74,7 @@ public class AccountService {
 
 
     @Transactional
-    public void withdrawal1(WithdrawalDTO request) {
+    public void withdrawal(WithdrawalDTO request) {
 
         Account main = accountRepository.findById(request.getMainAccountId())
                 .orElseThrow(() -> new IllegalArgumentException("메인 계좌를 찾을 수 없습니다."));
@@ -163,5 +163,18 @@ public class AccountService {
         List<DailyLimit> dailyLimitForAllUsers = dailyLimitRepository.findAll();
         dailyLimitForAllUsers.forEach(dailyLimit -> dailyLimit.resetDailyBalance(0));
     }
+
+    @Scheduled(cron = "0 0 4 * * ?")
+    @Transactional
+    public void savingInterest() {
+        List<Account> accounts = accountRepository.findAllSavingsAccounts();
+
+        for (Account a : accounts) {
+            long interest = (long) Math.ceil((a.getBalance() / 100) * 3);
+            a.addInterest(interest);
+        }
+    }
+
+
 
 }


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

변경점
- 기존 적금 ENUM : MAIN, SAVING
- 변경 적금 ENUM : MAIN, REGULAR_SAVING(정기적금), FREE_SAVING(자유적금)
- 적금계좌를 개설할 때 정기적금과 자유적금 중 선택하여 개설 가능(`정기적금 가입 시 적금 액수 지정`) 

기능 추가
- 매일 새벽 4시에 적금 계좌를 가진 모든 유저의 적금 유형에 따라 정기적금(이자:5%), 자유적금(이자:3%)의 이자를 지급
- 매일 오전 8시에 정기적금을 가진 모든 유저의 메인계좌에서 적금비용이 적금계좌로 이체된다.
  - 만약 `메인계좌에 금액이 부족하다면 송금 기능과 똑같이 만원단위로 자동 충전 후 송금`하게 된다.

## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## 📸 스크린샷

<img width="325" alt="스크린샷 2024-07-18 오후 2 57 24" src="https://github.com/user-attachments/assets/62b05570-4c3e-4e96-94a9-7615cc44573f">
<br>
- 똑같이 5000원이 들어있는 자유적금과 정기적금에 이자가 2% 차이나는 것을 볼 수 있다.
<br>
<br>
<img width="325" alt="스크린샷 2024-07-18 오후 3 00 00" src="https://github.com/user-attachments/assets/282cde64-11a1-47a0-ae19-2881818b8aac">
<br>
<img width="308" alt="스크린샷 2024-07-18 오후 3 00 16" src="https://github.com/user-attachments/assets/3e918752-3df0-4b56-b9db-e74ffff4d248">
<br>
- 10만원이 있는 메인계좌에서 11만원의 자유적금 출금 시 1만원 자동 충전 후 이체되는 부분을 볼 수 있다.



## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#9 

## 🙌 리뷰 및 피드백

(리뷰어들께 질문하거나 특정 리뷰를 요청하는 내용을 작성하세요.)