### PR TITLE
Fix/13 concurrency control

### DIFF
--- a/src/main/java/com/minipay/account/repository/AccountRepository.java
+++ b/src/main/java/com/minipay/account/repository/AccountRepository.java
@@ -3,9 +3,11 @@ package com.minipay.account.repository;
 import com.minipay.account.domain.Account;
 import com.minipay.account.domain.Type;
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
@@ -20,6 +22,7 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select a from Account a where a.id = :id")
+    @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value = "5000")})
     Account findByIdWithPessimisticLock(@Param("id") Long id);
 
     @Query("SELECT a FROM Account a WHERE a.type = 'FREE_SAVING' or a.type = 'REGULAR_SAVING'")

--- a/src/main/java/com/minipay/account/service/AccountService.java
+++ b/src/main/java/com/minipay/account/service/AccountService.java
@@ -79,10 +79,8 @@ public class AccountService {
     @Transactional
     public void withdrawal(WithdrawalDTO request) {
 
-        Account main = accountRepository.findById(request.getMainAccountId())
-                .orElseThrow(() -> new IllegalArgumentException("메인 계좌를 찾을 수 없습니다."));
-        Account saving = accountRepository.findById(request.getSavingAccountId())
-                .orElseThrow(() -> new IllegalArgumentException("적금 계좌를 찾을 수 없습니다."));
+        Account main = accountRepository.findByIdWithPessimisticLock(request.getMainAccountId());
+        Account saving = accountRepository.findByIdWithPessimisticLock(request.getSavingAccountId());
 
         if (main.getBalance()  < request.getBalance()) {
             throw new IllegalArgumentException("메인계좌의 잔액이 부족합니다");

--- a/src/main/java/com/minipay/account/service/AccountService.java
+++ b/src/main/java/com/minipay/account/service/AccountService.java
@@ -38,11 +38,10 @@ public class AccountService {
     @Transactional
     public void deposit(DepositDTO request) {
 
-        Account account = accountRepository.findById(request.getAccountId())
-                .orElseThrow(() -> new IllegalArgumentException("계좌를 찾을 수 없습니다."));
+        Account account = accountRepository.findByIdWithPessimisticLock(request.getAccountId());
 
         Long userId = account.getUser().getId();
-        DailyLimit dailyLimit = dailyLimitRepository.findById(userId).orElseThrow(IllegalArgumentException::new);
+        DailyLimit dailyLimit = dailyLimitRepository.findByIdWithPessimisticLock(userId);
         long dailyLimitBalance= dailyLimit.getDailyTotalBalance();
 
         if (dailyLimitBalance + request.getBalance() > TODAY_LIMIT) {

--- a/src/main/java/com/minipay/daliyLimit/repository/DailyLimitRepository.java
+++ b/src/main/java/com/minipay/daliyLimit/repository/DailyLimitRepository.java
@@ -1,9 +1,20 @@
 package com.minipay.daliyLimit.repository;
 
 import com.minipay.daliyLimit.domain.DailyLimit;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DailyLimitRepository extends JpaRepository<DailyLimit, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select d from DailyLimit d where d.id = :id")
+    @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value = "5000")})
+    DailyLimit findByIdWithPessimisticLock(@Param("id") Long id);
 }


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

데이터 정합성 문제가 발생할 수 있는 주요 메서드에 비관적 락 + 타임아웃을 설정하여 방지합니다.


## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 버그 수정

## 📸 스크린샷

(선택 사항: 변경된 내용을 시각적으로 보여주기 위해 스크린샷을 첨부하세요.)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#13 

## 🙌 리뷰 및 피드백

(리뷰어들께 질문하거나 특정 리뷰를 요청하는 내용을 작성하세요.)